### PR TITLE
optional parameter params for getList

### DIFF
--- a/lib/core/domainDaoSupport.js
+++ b/lib/core/domainDaoSupport.js
@@ -671,6 +671,12 @@ DomainDaoSupport.prototype.getList = function(sql, params, options, cb) {
 	var func = tableConfig.getFunc();
 	var self = this;
 
+	if (Utils.checkFunction(params)) {
+		cb = params;
+		params = [];
+		options = {};
+	}
+	
 	if (Utils.checkString(options)) {
 		mid = options || mid;
 		options = {};


### PR DESCRIPTION
when executing a query without parameter, it is still nessasary to provide an empty Array as parameter.  In our team we fall the second time into this trap.

this.$domainDaoSupport.getList("$getProducts", function(err,products){
...
