### PR TITLE
user error stack, optional params

### DIFF
--- a/lib/core/domainDaoSupport.js
+++ b/lib/core/domainDaoSupport.js
@@ -696,6 +696,11 @@ DomainDaoSupport.prototype.getList = function(sql, params, options, cb) {
 	if (Utils.isNotNull(limit) && Utils.isNotNull(offset)) {
 		sql = SqlBuilderUtil.appendLimit(sql, limit, offset);
 	}
+	
+	if(Utils.checkFunction(params)){
+		cb = params;
+		params = [];
+	}
 
 	return this.getSqlTemplate().executeQuery(sql, params, function(err, results) {
 		if (err) {
@@ -797,6 +802,11 @@ DomainDaoSupport.prototype.get = function(sql, params, cb) {
 	var mid = tableConfig.getMid();
 	var func = tableConfig.getFunc();
 
+	if(Utils.checkFunction(params)){
+		cb = params;
+		params = [];
+	}
+	
 	return this.getSqlTemplate().executeQuery(sql, params, function(err, results) {
 		if (err) {
 			return cb(err);
@@ -825,6 +835,11 @@ DomainDaoSupport.prototype.get = function(sql, params, cb) {
  * @api public
  */
 DomainDaoSupport.prototype.getCount = function(sql, params, cb) {
+	if(Utils.checkFunction(params)){
+		cb = params;
+		params = [];
+	}
+	
 	sql = SqlBuilderUtil.getSql(sql);
 	return this.getSqlTemplate().queryCount(sql, params, cb);
 }
@@ -907,6 +922,11 @@ DomainDaoSupport.prototype.update = function(sql, params, cb) {
  * @api public
  */
 DomainDaoSupport.prototype.exists = function(sql, params, cb) {
+	if(Utils.checkFunction(params)){
+		cb = params;
+		params = [];
+	}
+	
 	sql = SqlBuilderUtil.getSql(sql);
 	return this.getSqlTemplate().existRecord(sql, params, cb);
 }

--- a/lib/template/sql/mysqlTemplate.js
+++ b/lib/template/sql/mysqlTemplate.js
@@ -143,8 +143,9 @@ MysqlTemplate.prototype.getIdTableName = function(idTableName) {
 MysqlTemplate.prototype.allocateRecordId = function(tableName, cb) {
 	var self = this;
 	var idTableName = this.getIdTableName();
+	var userErrorStack = new Error().stack;
 	this.getConnection(function(err, connection, tx) {
-		if (self.handleError(err, cb)) {
+		if (self.handleError(err, userErrorStack, cb)) {
 			return self;
 		}
 		var sql = 'UPDATE ' + idTableName + ' SET id = LAST_INSERT_ID(id + 1) WHERE name = ?';
@@ -152,7 +153,7 @@ MysqlTemplate.prototype.allocateRecordId = function(tableName, cb) {
 			if (!tx) {
 				self.connectionManager.release(connection);
 			}
-			if (self.handleError(err, cb)) {
+			if (self.handleError(err, userErrorStack, cb)) {
 				return self;
 			}
 			var id = -1;
@@ -163,7 +164,7 @@ MysqlTemplate.prototype.allocateRecordId = function(tableName, cb) {
 			if (id === -1) {
 				sql = 'INSERT INTO ' + idTableName + ' (name, id) values (?, 0)';
 				self.executeUpdate(sql, [tableName], function(err) {
-					if (self.handleError(err, cb)) {
+					if (self.handleError(err, userErrorStack, cb)) {
 						return self;
 					}
 
@@ -224,9 +225,9 @@ MysqlTemplate.prototype.batchAddRecords = function(sql, paramList, cb) {
  */
 MysqlTemplate.prototype.existRecord = function(sql, params, cb) {
 	var self = this;
-
+	var userErrorStack = new Error().stack;
 	this.getConnection(function(err, connection, tx) {
-		if (self.handleError(err, cb)) {
+		if (self.handleError(err, userErrorStack, cb)) {
 			return;
 		}
 
@@ -234,7 +235,7 @@ MysqlTemplate.prototype.existRecord = function(sql, params, cb) {
 			if (!tx) {
 				self.connectionManager.release(connection);
 			}
-			if (self.handleError(err, cb)) {
+			if (self.handleError(err, userErrorStack, cb)) {
 				return self;
 			}
 			if (results && results.length) {
@@ -294,8 +295,9 @@ MysqlTemplate.prototype.batchUpdateRecords = function(sql, paramList, cb) {
  */
 MysqlTemplate.prototype.queryCount = function(sql, params, cb) {
 	var self = this;
+	var userErrorStack = new Error().stack;
 	this.getConnection(function(err, connection, tx) {
-		if (self.handleError(err, cb)) {
+		if (self.handleError(err, userErrorStack, cb)) {
 			return;
 		}
 
@@ -303,7 +305,7 @@ MysqlTemplate.prototype.queryCount = function(sql, params, cb) {
 			if (!tx) {
 				self.connectionManager.release(connection);
 			}
-			if (self.handleError(err, cb)) {
+			if (self.handleError(err, userErrorStack, cb)) {
 				return self;
 			}
 			if (results && results.length) {
@@ -327,8 +329,9 @@ MysqlTemplate.prototype.queryCount = function(sql, params, cb) {
  */
 MysqlTemplate.prototype.executeQuery = function(sql, params, cb) {
 	var self = this;
+	var userErrorStack = new Error().stack;
 	this.getConnection(function(err, connection, tx) {
-		if (self.handleError(err, cb)) {
+		if (self.handleError(err, userErrorStack, cb)) {
 			return self;
 		}
 
@@ -336,7 +339,7 @@ MysqlTemplate.prototype.executeQuery = function(sql, params, cb) {
 			if (!tx) {
 				self.connectionManager.release(connection);
 			}
-			if (self.handleError(err, cb)) {
+			if (self.handleError(err, userErrorStack, cb)) {
 				return self;
 			}
 			cb(null, results);
@@ -467,8 +470,9 @@ MysqlTemplate.prototype.directUpdateById = function(object, options, cb) {
  */
 MysqlTemplate.prototype.executeUpdate = function(sql, params, cb) {
 	var self = this;
+	var userErrorStack = new Error().stack;
 	this.getConnection(function(err, connection, tx) {
-		if (self.handleError(err, cb)) {
+		if (self.handleError(err, userErrorStack, cb)) {
 			return self;
 		}
 
@@ -476,7 +480,7 @@ MysqlTemplate.prototype.executeUpdate = function(sql, params, cb) {
 			if (!tx) {
 				self.connectionManager.release(connection);
 			}
-			if (self.handleError(err, cb)) {
+			if (self.handleError(err, userErrorStack, cb)) {
 				return self;
 			}
 			if (result && result['affectedRows']) {
@@ -536,8 +540,15 @@ MysqlTemplate.prototype.print = function(sql) {
  * @param  {Function} cb callback function
  * @api private
  */
-MysqlTemplate.prototype.handleError = function(err, cb) {
+MysqlTemplate.prototype.handleError = function(err, userErrorStack, cb) {
+	if(typeof userErrorStack == 'function'){
+		cb = userErrorStack;
+		userErrorStack = '';
+	}
 	if (err) {
+		if(err instanceof Error){
+			err.stack += '\n'+userErrorStack;
+		}
 		cb(err);
 		return true;
 	}


### PR DESCRIPTION
changes in dimainDaoSupport, to allow params as optional parameter. if params is not passed the result was directly the mysql result-list and the connection was not returned to the pool

second is for debugging.
when there is an error, if was impossible to see where the error came from in the users project.
the error-stack has only shown from mysql-getConnection over pomelo to mysql query. 
now it will also provide information, where the user of Bearcat dao has triggered the query. 

Both changes are not breaking any API and are fully compatible with existing projects
